### PR TITLE
Add type caster for units::scalar_t

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ libs = ["wpiutil"]
     "units::radian_t", "units::radians_per_second_t",
     "units::volt_t",
     "units::turn_t",
+    "units::scalar_t",
 ]
 
 [tool.robotpy-build.metadata]

--- a/wpiutil/src/type_casters/units_unit_t_type_caster.h
+++ b/wpiutil/src/type_casters/units_unit_t_type_caster.h
@@ -25,6 +25,8 @@ PYBIND_UNIT_NAME(radians_per_second, radians_per_second);
 PYBIND_UNIT_NAME(volt, volts);
 PYBIND_UNIT_NAME(turn, turns);
 
+PYBIND_UNIT_NAME(scalar, float);
+
 #undef PYBIND_UNIT_NAME
 
 


### PR DESCRIPTION
This will be useful for binding to some of WPILib's unit-safe classes.