### PR TITLE
Give m/s^2 a readable name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ libs = ["wpiutil"]
     "units::unit_t", "units::compound_unit",
     "units::second_t", "units::millisecond_t",
     "units::microsecond_t", "units::nanosecond_t",
-    "units::meter_t", "units::meters_per_second_t",
+    "units::meter_t", "units::meters_per_second_t", "units::meters_per_second_squared_t",
     "units::degree_t",
     "units::radian_t", "units::radians_per_second_t",
     "units::volt_t",

--- a/wpiutil/src/type_casters/units_unit_t_type_caster.h
+++ b/wpiutil/src/type_casters/units_unit_t_type_caster.h
@@ -19,6 +19,7 @@ PYBIND_UNIT_NAME(nanosecond, nanoseconds);
 PYBIND_UNIT_NAME(meter, meters);
 PYBIND_UNIT_NAME(foot, feet);
 PYBIND_UNIT_NAME(meters_per_second, meters_per_second);
+PYBIND_UNIT_NAME(meters_per_second_squared, meters_per_second_squared);
 PYBIND_UNIT_NAME(feet_per_second, feet_per_second);
 PYBIND_UNIT_NAME(degree, degrees);
 PYBIND_UNIT_NAME(radian, radians);


### PR DESCRIPTION
This is used in frc::TrajectoryConfig.