### PR TITLE
Add python stack trace hook

### DIFF
--- a/gen/StackTrace.yml
+++ b/gen/StackTrace.yml
@@ -1,0 +1,5 @@
+functions:
+  GetStackTrace:
+  GetStackTraceDefault:
+  SetGetStackTraceImpl:
+    ignore: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,15 @@ base_package = "wpiutil"
 
 [tool.robotpy-build.wrappers."wpiutil"]
 name = "wpiutil"
-sources = ["wpiutil/src/main.cpp"]
+sources = [
+    "wpiutil/src/main.cpp",
+    "wpiutil/src/stacktracehook.cpp"
+]
 extra_includes = ["wpiutil/src/type_casters"]
 
 generate = [
     { PortForwarder = "wpi/PortForwarder.h" },
+    { StackTrace = "wpi/StackTrace.h" },
 
     # wpi/sendable
     { Sendable = "wpi/sendable/Sendable.h" },

--- a/tests/test_stacktrace.py
+++ b/tests/test_stacktrace.py
@@ -1,0 +1,9 @@
+import wpiutil
+
+
+def test_python_stack_trace():
+    st = wpiutil._wpiutil.getStackTrace(0)
+    assert __file__ in st
+
+    st = wpiutil._wpiutil.getStackTraceDefault(0)
+    assert __file__ not in st

--- a/wpiutil/__init__.py
+++ b/wpiutil/__init__.py
@@ -4,3 +4,6 @@ from . import _init_wpiutil
 from ._wpiutil import PortForwarder
 
 __all__ = ["PortForwarder"]
+
+# Imported for side effects only
+from . import _stacktrace

--- a/wpiutil/_stacktrace.py
+++ b/wpiutil/_stacktrace.py
@@ -1,0 +1,27 @@
+from traceback import extract_stack, format_list
+from ._wpiutil import getStackTraceDefault, _setup_stack_trace_hook
+from os.path import join
+
+_start_py = join("wpilib", "_impl", "start.py")
+
+
+def _stack_trace_hook(offset: int) -> str:
+    # note: this implementation ignores offset because it's not
+    # actually meaningful when crossing the python/C++ boundary
+
+    stack = extract_stack()[:-1]
+    if not stack:
+        return "\tat <no python frames>\n" + getStackTraceDefault()
+
+    # filter out any frames before start.py (except for one of them) to
+    # make stack frames more useful for users
+    for i in range(len(stack) - 1, 0, -1):
+        if stack[i].filename.endswith(_start_py):
+            stack = stack[i:]
+            break
+
+    trace = format_list(stack)
+    return "\n".join(trace)
+
+
+_setup_stack_trace_hook(_stack_trace_hook)

--- a/wpiutil/src/main.cpp
+++ b/wpiutil/src/main.cpp
@@ -1,6 +1,15 @@
 
 #include <rpygen_wrapper.hpp>
 
+void setup_stack_trace_hook(py::object fn);
+void cleanup_stack_trace_hook();
+
 RPYBUILD_PYBIND11_MODULE(m) {
-    initWrapper(m);
+  initWrapper(m);
+
+  static int unused;
+  py::capsule cleanup(&unused, [](void *) { cleanup_stack_trace_hook(); });
+
+  m.def("_setup_stack_trace_hook", &setup_stack_trace_hook);
+  m.add_object("_st_cleanup", cleanup);
 }

--- a/wpiutil/src/stacktracehook.cpp
+++ b/wpiutil/src/stacktracehook.cpp
@@ -1,0 +1,39 @@
+
+#include <robotpy_build.h>
+#include <wpi/StackTrace.h>
+
+py::object &get_hook_ref() {
+  static py::object hook;
+  return hook;
+}
+
+std::string py_stack_trace_hook(int offset) {
+  py::gil_scoped_acquire gil;
+
+  try {
+    auto &hook = get_hook_ref();
+    if (hook) {
+      return py::cast<std::string>(hook(offset));
+    }
+  } catch (py::error_already_set &e) {
+    e.discard_as_unraisable("wpiutil._stacktrace._stack_trace_hook");
+  }
+
+  return wpi::GetStackTraceDefault(offset);
+}
+
+void setup_stack_trace_hook(py::object fn) {
+  get_hook_ref() = fn;
+  wpi::SetGetStackTraceImpl(py_stack_trace_hook);
+}
+
+void cleanup_stack_trace_hook() {
+  wpi::SetGetStackTraceImpl(nullptr);
+
+  // release the function during interpreter shutdown
+  auto &hook = get_hook_ref();
+  if (hook) {
+    hook.dec_ref();
+    hook.release();
+  }
+}


### PR DESCRIPTION
- Makes stack traces useful for python users... they'll look something like this:

```
Warning: Joystick Axis 1 missing (max 0), check if all controllers are plugged in
  File "wpilib/_impl/start.py", line 124, in _start
    self.robot.startCompetition()

  File "./robot.py", line 49, in teleopPeriodic
    y = self.rstick.getY()
```