### PR TITLE
Add specializations to span caster for uint8_t

### DIFF
--- a/tests/cpp/wpiutil_test/module.cpp
+++ b/tests/cpp/wpiutil_test/module.cpp
@@ -59,6 +59,14 @@ py::object cast_string_span() {
     return py::cast(make_string_span());
 }
 
+wpi::span<const uint8_t> load_span_bytes(wpi::span<const uint8_t> ref) {
+    return ref;
+}
+
+void modify_span_buffer(wpi::span<uint8_t> ref) {
+    ref[0] = 0x4;
+}
+
 /*
 SmallSet tests
 */
@@ -115,6 +123,8 @@ RPYBUILD_PYBIND11_MODULE(m) {
     m.def("load_span_vector", &load_span_vector);
     m.def("cast_span", &cast_span);
     m.def("cast_string_span", &cast_string_span);
+    m.def("load_span_bytes", &load_span_bytes);
+    m.def("modify_span_buffer", &modify_span_buffer);
     // SmallSet
     m.def("load_smallset_int", &load_smallset_int);
     m.def("cast_smallset", &cast_smallset);

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -1,4 +1,6 @@
+import pytest
 from wpiutil_test import module
+import array
 
 
 def test_span_load_int():
@@ -27,6 +29,35 @@ def test_span_load_stringview():
 
 def test_span_load_vector():
     assert module.load_span_vector([["a"], ["b"], ["c"]]) == [["a"], ["b"], ["c"]]
+
+
+def test_span_load_buffer_bytes():
+    assert module.load_span_bytes(b"abc") == b"abc"
+
+
+def test_span_modify_buffer_bytes():
+    b = b"abc"
+    with pytest.raises(BufferError):
+        module.modify_span_buffer(b)
+
+
+def test_span_load_buffer_bytearray():
+    assert module.load_span_bytes(bytearray([1, 2, 3])) == b"\x01\x02\x03"
+
+
+def test_span_modify_buffer_bytearray():
+    b = bytearray([1, 2, 3])
+    module.modify_span_buffer(b)
+    assert b == bytearray([4, 2, 3])
+
+
+def test_span_load_buffer_array():
+    a = array.array("l")
+    a.append(1)
+    a2 = array.array("l")
+    a2.frombytes(module.load_span_bytes(a))
+    assert len(a2) == 1
+    assert a2[0] == 1
 
 
 def test_span_cast():


### PR DESCRIPTION
- Typical use is going to be some kind of memory buffer, so we allow anything
  that implements the buffer protocol to work

@auscompgeek I couldn't find anything that this would break. It's useful for the datalog stuff. Thoughts?