### PR TITLE
Sendable::InitSendable: force builder to be a reference

### DIFF
--- a/gen/Sendable.yml
+++ b/gen/Sendable.yml
@@ -8,3 +8,8 @@ classes:
     shared_ptr: true
     methods:
       InitSendable:
+        virtual_xform: |
+          [&](py::function fn) {
+            auto builderHandle = py::cast(builder, py::return_value_policy::reference);
+            fn(builderHandle);
+          }

--- a/tests/cpp/pyproject.toml
+++ b/tests/cpp/pyproject.toml
@@ -10,6 +10,7 @@ extension = "module"
 depends = ["wpiutil"]
 sources = [
     "wpiutil_test/module.cpp",
+    "wpiutil_test/sendable_test.cpp",
 ]
 
 [tool.robotpy-build.metadata]

--- a/tests/cpp/wpiutil_test/module.cpp
+++ b/tests/cpp/wpiutil_test/module.cpp
@@ -144,8 +144,12 @@ wpi::json cast_json_val(std::function<wpi::json()> fn) {
     return fn();
 }
 
+void sendable_test(py::module &m);
+
 
 RPYBUILD_PYBIND11_MODULE(m) {
+
+    sendable_test(m);
 
     // array
     m.def("load_array_int", &load_array_int);

--- a/tests/cpp/wpiutil_test/sendable_test.cpp
+++ b/tests/cpp/wpiutil_test/sendable_test.cpp
@@ -1,0 +1,127 @@
+
+#include <robotpy_build.h>
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
+#include <wpi/sendable/SendableBuilder.h>
+#include <wpi/sendable/SendableRegistry.h>
+
+class MySendableBuilder : public wpi::SendableBuilder {
+public:
+  MySendableBuilder(py::dict keys) : keys(keys) {}
+
+  ~MySendableBuilder() {
+    // leak this so the python interpreter doesn't crash on shutdown
+    keys.release();
+  }
+
+  void SetSmartDashboardType(std::string_view type) override {}
+
+  void SetActuator(bool value) override {}
+
+  void SetSafeState(std::function<void()> func) override {}
+
+  void AddBooleanProperty(std::string_view key, std::function<bool()> getter,
+                          std::function<void(bool)> setter) override {}
+
+  void AddIntegerProperty(std::string_view key, std::function<int64_t()> getter,
+                          std::function<void(int64_t)> setter) override {}
+
+  void AddFloatProperty(std::string_view key, std::function<float()> getter,
+                        std::function<void(float)> setter) override {}
+
+  void AddDoubleProperty(std::string_view key, std::function<double()> getter,
+                         std::function<void(double)> setter) override {
+    py::gil_scoped_acquire gil;
+    py::object pykey = py::cast(key);
+    keys[pykey] = std::make_tuple(getter, setter);
+  }
+
+  void
+  AddStringProperty(std::string_view key, std::function<std::string()> getter,
+                    std::function<void(std::string_view)> setter) override {}
+
+  void AddBooleanArrayProperty(
+      std::string_view key, std::function<std::vector<int>()> getter,
+      std::function<void(std::span<const int>)> setter) override {}
+
+  void AddIntegerArrayProperty(
+      std::string_view key, std::function<std::vector<int64_t>()> getter,
+      std::function<void(std::span<const int64_t>)> setter) override {}
+
+  void AddFloatArrayProperty(
+      std::string_view key, std::function<std::vector<float>()> getter,
+      std::function<void(std::span<const float>)> setter) override {}
+
+  void AddDoubleArrayProperty(
+      std::string_view key, std::function<std::vector<double>()> getter,
+      std::function<void(std::span<const double>)> setter) override {}
+
+  void AddStringArrayProperty(
+      std::string_view key, std::function<std::vector<std::string>()> getter,
+      std::function<void(std::span<const std::string>)> setter) override {}
+
+  void AddRawProperty(
+      std::string_view key, std::string_view typeString,
+      std::function<std::vector<uint8_t>()> getter,
+      std::function<void(std::span<const uint8_t>)> setter) override {}
+
+  void AddSmallStringProperty(
+      std::string_view key,
+      std::function<std::string_view(wpi::SmallVectorImpl<char> &buf)> getter,
+      std::function<void(std::string_view)> setter) override {}
+
+  void AddSmallBooleanArrayProperty(
+      std::string_view key,
+      std::function<std::span<const int>(wpi::SmallVectorImpl<int> &buf)>
+          getter,
+      std::function<void(std::span<const int>)> setter) override {}
+
+  void AddSmallIntegerArrayProperty(
+      std::string_view key,
+      std::function<
+          std::span<const int64_t>(wpi::SmallVectorImpl<int64_t> &buf)>
+          getter,
+      std::function<void(std::span<const int64_t>)> setter) override {}
+
+  void AddSmallFloatArrayProperty(
+      std::string_view key,
+      std::function<std::span<const float>(wpi::SmallVectorImpl<float> &buf)>
+          getter,
+      std::function<void(std::span<const float>)> setter) override {}
+
+  void AddSmallDoubleArrayProperty(
+      std::string_view key,
+      std::function<std::span<const double>(wpi::SmallVectorImpl<double> &buf)>
+          getter,
+      std::function<void(std::span<const double>)> setter) override {}
+
+  void AddSmallStringArrayProperty(
+      std::string_view key,
+      std::function<
+          std::span<const std::string>(wpi::SmallVectorImpl<std::string> &buf)>
+          getter,
+      std::function<void(std::span<const std::string>)> setter) override {}
+
+  void AddSmallRawProperty(
+      std::string_view key, std::string_view typeString,
+      std::function<std::span<uint8_t>(wpi::SmallVectorImpl<uint8_t> &buf)>
+          getter,
+      std::function<void(std::span<const uint8_t>)> setter) override {}
+
+  wpi::SendableBuilder::BackendKind GetBackendKind() const override {
+    return wpi::SendableBuilder::BackendKind::kUnknown;
+  }
+
+  bool IsPublished() const override { return false; }
+  void Update() override {}
+  void ClearProperties() override {}
+
+  py::dict keys;
+};
+
+void Publish(wpi::SendableRegistry::UID sendableUid, py::dict keys) {
+  auto builder = std::make_unique<MySendableBuilder>(keys);
+  wpi::SendableRegistry::Publish(sendableUid, std::move(builder));
+}
+
+void sendable_test(py::module &m) { m.def("publish", Publish); }

--- a/tests/test_sendable.py
+++ b/tests/test_sendable.py
@@ -1,0 +1,35 @@
+import typing
+import wpiutil
+from wpiutil_test import module
+
+
+class MySendable(wpiutil.Sendable):
+    def __init__(self):
+        super().__init__()
+        wpiutil.SendableRegistry.add(self, "Test", 1)
+        self.value = 0
+
+    def initSendable(self, builder: wpiutil.SendableBuilder):
+        builder.addDoubleProperty("key", self._get, self._set)
+
+    def _set(self, value: float):
+        self.value = value
+
+    def _get(self) -> float:
+        return self.value
+
+
+def test_custom_sendable():
+    ms = MySendable()
+
+    uid = wpiutil.SendableRegistry.getUniqueId(ms)
+    keys = {}
+
+    module.publish(uid, keys)
+    assert ms.value == 0
+
+    getter, setter = keys["key"]
+    assert getter() == 0
+    setter(1)
+    assert getter() == 1
+    assert ms.value == 1

--- a/wpiutil/src/main.cpp
+++ b/wpiutil/src/main.cpp
@@ -4,11 +4,22 @@
 void setup_stack_trace_hook(py::object fn);
 void cleanup_stack_trace_hook();
 
+namespace wpi::impl {
+void ResetSendableRegistry();
+} // namespace wpi::impl
+
 RPYBUILD_PYBIND11_MODULE(m) {
   initWrapper(m);
 
   static int unused;
-  py::capsule cleanup(&unused, [](void *) { cleanup_stack_trace_hook(); });
+  py::capsule cleanup(&unused, [](void *) {
+    {
+      py::gil_scoped_release unlock;
+      wpi::impl::ResetSendableRegistry();
+    }
+
+    cleanup_stack_trace_hook();
+  });
 
   m.def("_setup_stack_trace_hook", &setup_stack_trace_hook);
   m.add_object("_st_cleanup", cleanup);


### PR DESCRIPTION
- Not really sure why it isn't already a reference?
- Fixes robotpy/robotpy-wpilib#630
- Should add tests, and an override for NTSendable in ntcore as well

Unfortunately, this isn't the whole story here. Actually using the builder causes ntcore to abort() on robot exit (which... that probably already happens when you add a listener? Need to test that) because the listener gets deregistered on python shutdown, which causes the std::function wrappers for get/set to be destroyed, which tries to take the GIL, which aborts because you can't take the GIL on another python thread on shutdown.

Related bugs:
* https://github.com/pytorch/pytorch/issues/38228
* https://github.com/pybind/pybind11/issues/2215
* There is a gil disarm in https://github.com/pybind/pybind11/pull/2657, but I don't think that helps us at all

The Right Fix is to force ntcore to use our thread instead of its own thread, but even if we added a ntcore poller thread that wouldn't resolve the issue (a la Java) because we can't intercept the builder's callback registration easily.